### PR TITLE
Update zplug install instruction

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ Add `zgen load zsh-users/zsh-syntax-highlighting` to the end of your `.zshrc`.
 
 #### [zplug](https://github.com/zplug/zplug)
 
-Add `zplug "zsh-users/zsh-syntax-highlighting", nice:10` to your `.zshrc`.
+Add `zplug "zsh-users/zsh-syntax-highlighting", defer:2` to your `.zshrc`.
 
 #### [zplugin](https://github.com/psprint/zplugin)
 


### PR DESCRIPTION
The latest version of zplug has deprecated the `nice` tag. The `defer` tag is the preferred method now.